### PR TITLE
Hardcode Git Origin URL To HTTPS So SSH Cannot Be Set By Accident

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ echo $ASB_CLUSTER_ADMIN_ID
 ```bash
 
 # set GitOps repo
-export ASB_GIT_REPO=$(git remote get-url origin)
+export ASB_GIT_REPO=https://github.com/asb-spark/openhack.git
 export ASB_GIT_BRANCH=$ASB_TEAM_NAME
 export ASB_GIT_PATH=gitops
 


### PR DESCRIPTION
## Purpose of PR
- Hardcode Git Origin URL To HTTPS So SSH Cannot Be Set By Accident

# Type of PR

- [X] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Issues Closed or Referenced

- Closes #364
